### PR TITLE
Update module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tendermint/tendermint
+module github.com/airchains-network/tracksbft
 
 go 1.19
 


### PR DESCRIPTION
The module name has been updated in the go.mod file. The previous name 'github.com/tendermint/tendermint' has been replaced with 'github.com/airchains-network/tracksbft'. This change aligns with the recent restructuring of the project.
